### PR TITLE
feat(jpeg): Hardware JPEG Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,5 @@ idf_component_register(
         "include"
     PRIV_INCLUDE_DIRS
         ${PRIV_INCLUDE_DIRS}
-    REQUIRES esp_timer
+    REQUIRES esp_timer esp_driver_jpeg
 )

--- a/include/widget/gfx_img.h
+++ b/include/widget/gfx_img.h
@@ -49,6 +49,17 @@ typedef struct {
 } gfx_image_dsc_t;
 
 /**
+ * @brief In-memory JPEG bitstream descriptor.
+ *
+ * The JPEG payload stays owned by the caller. The decoder may copy the input
+ * into a hardware-friendly buffer during draw.
+ */
+typedef struct {
+    const uint8_t *data;        /**< Pointer to the JPEG bitstream */
+    uint32_t data_size;         /**< Size of the JPEG bitstream in bytes */
+} gfx_jpeg_dsc_t;
+
+/**
  * @brief Public image source type.
  *
  * Use this enum together with `gfx_img_src_t` to describe where an image
@@ -57,6 +68,7 @@ typedef struct {
  */
 typedef enum {
     GFX_IMG_SRC_TYPE_IMAGE_DSC = 0, /**< In-memory gfx_image_dsc_t payload */
+    GFX_IMG_SRC_TYPE_JPEG = 1,      /**< In-memory gfx_jpeg_dsc_t payload */
 } gfx_img_src_type_t;
 
 /**

--- a/src/lib/eaf/gfx_eaf_dec.c
+++ b/src/lib/eaf/gfx_eaf_dec.c
@@ -18,6 +18,9 @@
 #include "gfx_eaf_dec.h"
 #if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT
 #include "esp_jpeg_dec.h"
+#if CONFIG_SOC_JPEG_DECODE_SUPPORTED
+#include "driver/jpeg_decode.h"
+#endif
 #endif
 
 #ifdef CONFIG_GFX_EAF_HEATSHRINK_SUPPORT
@@ -47,6 +50,10 @@
 
 static const char *TAG = "eaf_dec";
 static eaf_dec_block_decoder_cb_t s_eaf_decoders[EAF_DEC_ENCODING_MAX] = {0};
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT && CONFIG_SOC_JPEG_DECODE_SUPPORTED
+static jpeg_decoder_handle_t s_eaf_jpeg_decoder_engine = NULL;
+static uint32_t s_eaf_parser_count = 0;
+#endif
 
 /**********************
  *  STATIC PROTOTYPES
@@ -58,6 +65,16 @@ static void huffman_tree_free(eaf_dec_huffman_node_t *node);
 static esp_err_t huffman_decode_data(const uint8_t *in_data, size_t in_size,
                                      const uint8_t *dict_data, size_t dict_len,
                                      uint8_t *out_data, size_t *out_size);
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT && CONFIG_SOC_JPEG_DECODE_SUPPORTED
+static jpeg_dec_rgb_element_order_t eaf_dec_get_jpeg_rgb_order(bool swap_color);
+static esp_err_t eaf_dec_ensure_hw_jpeg_engine(void);
+static esp_err_t eaf_dec_decode_jpeg_hardware(const uint8_t *in_data, size_t in_size,
+        uint8_t *out_data, size_t *out_size, bool swap_color);
+#endif
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT
+static esp_err_t eaf_dec_decode_jpeg_software(const uint8_t *in_data, size_t in_size,
+        uint8_t *out_data, size_t *out_size, bool swap_color);
+#endif
 
 /**********************
  *   STATIC FUNCTIONS
@@ -166,6 +183,180 @@ static esp_err_t huffman_decode_data(const uint8_t *in_data, size_t in_size,
     huffman_tree_free(root);
     return ESP_OK;
 }
+
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT && CONFIG_SOC_JPEG_DECODE_SUPPORTED
+static jpeg_dec_rgb_element_order_t eaf_dec_get_jpeg_rgb_order(bool swap_color)
+{
+    /* Keep hardware output aligned with the software fallback:
+     * swap_color=false -> RGB565 little-endian
+     * swap_color=true  -> RGB565 big-endian */
+    return swap_color ? JPEG_DEC_RGB_ELEMENT_ORDER_RGB : JPEG_DEC_RGB_ELEMENT_ORDER_BGR;
+}
+
+static esp_err_t eaf_dec_ensure_hw_jpeg_engine(void)
+{
+    if (s_eaf_jpeg_decoder_engine != NULL) {
+        return ESP_OK;
+    }
+
+    jpeg_decode_engine_cfg_t engine_cfg = {
+        .intr_priority = 0,
+        .timeout_ms = -1,
+    };
+
+    esp_err_t ret = jpeg_new_decoder_engine(&engine_cfg, &s_eaf_jpeg_decoder_engine);
+    if (ret != ESP_OK) {
+        GFX_LOGE(TAG, "JPEG decoder open failed: %s", esp_err_to_name(ret));
+    }
+
+    return ret;
+}
+
+static esp_err_t eaf_dec_decode_jpeg_hardware(const uint8_t *in_data, size_t in_size,
+        uint8_t *out_data, size_t *out_size, bool swap_color)
+{
+    jpeg_decode_picture_info_t picture_info = {0};
+    jpeg_decode_cfg_t decode_cfg = {
+        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .rgb_order = eaf_dec_get_jpeg_rgb_order(swap_color),
+        .conv_std = JPEG_YUV_RGB_CONV_STD_BT601,
+    };
+    jpeg_decode_memory_alloc_cfg_t input_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_INPUT_BUFFER,
+    };
+    jpeg_decode_memory_alloc_cfg_t output_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
+    };
+    uint8_t *input_buf = NULL;
+    uint8_t *decode_buf = NULL;
+    size_t input_buf_size = 0;
+    size_t decode_buf_size = 0;
+    uint32_t process_w = 0;
+    uint32_t process_h = 0;
+    uint32_t decoded_size = 0;
+    uint32_t mcu_w = 0;
+    uint32_t mcu_h = 0;
+    size_t required_size = 0;
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_FALSE(in_data != NULL && out_data != NULL && out_size != NULL, ESP_ERR_INVALID_ARG, TAG, "Invalid JPEG decode arguments");
+    ESP_RETURN_ON_ERROR(eaf_dec_ensure_hw_jpeg_engine(), TAG, "Hardware JPEG engine unavailable");
+    ESP_RETURN_ON_ERROR(jpeg_decoder_get_info(in_data, in_size, &picture_info), TAG, "JPEG get info failed");
+
+    switch (picture_info.sample_method) {
+    case JPEG_DOWN_SAMPLING_YUV444:
+        mcu_w = 8U;
+        mcu_h = 8U;
+        break;
+    case JPEG_DOWN_SAMPLING_YUV422:
+        mcu_w = 16U;
+        mcu_h = 8U;
+        break;
+    case JPEG_DOWN_SAMPLING_YUV420:
+        mcu_w = 16U;
+        mcu_h = 16U;
+        break;
+    default:
+        GFX_LOGW(TAG, "Unsupported hardware JPEG sample method %d", (int)picture_info.sample_method);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    process_w = ((picture_info.width + mcu_w - 1U) / mcu_w) * mcu_w;
+    process_h = ((picture_info.height + mcu_h - 1U) / mcu_h) * mcu_h;
+    required_size = (size_t)picture_info.width * (size_t)picture_info.height * sizeof(gfx_color_t);
+    ESP_RETURN_ON_FALSE(*out_size >= required_size, ESP_ERR_INVALID_SIZE, TAG,
+                        "Buffer too small: need %zu, got %zu", required_size, *out_size);
+
+    input_buf = jpeg_alloc_decoder_mem(in_size, &input_mem_cfg, &input_buf_size);
+    ESP_GOTO_ON_FALSE(input_buf != NULL, ESP_ERR_NO_MEM, err, TAG, "No mem for JPEG input buffer");
+    memcpy(input_buf, in_data, in_size);
+    (void)input_buf_size;
+
+    decode_buf = jpeg_alloc_decoder_mem((size_t)process_w * (size_t)process_h * sizeof(gfx_color_t), &output_mem_cfg, &decode_buf_size);
+    ESP_GOTO_ON_FALSE(decode_buf != NULL, ESP_ERR_NO_MEM, err, TAG, "No mem for JPEG output buffer");
+
+    ret = jpeg_decoder_process(s_eaf_jpeg_decoder_engine, &decode_cfg, input_buf, in_size,
+                               decode_buf, decode_buf_size, &decoded_size);
+    ESP_GOTO_ON_ERROR(ret, err, TAG, "JPEG decode failed");
+
+    for (uint32_t row = 0; row < picture_info.height; row++) {
+        const uint8_t *src_row = decode_buf + (size_t)row * process_w * sizeof(gfx_color_t);
+        uint8_t *dst_row = out_data + (size_t)row * picture_info.width * sizeof(gfx_color_t);
+        memcpy(dst_row, src_row, (size_t)picture_info.width * sizeof(gfx_color_t));
+    }
+
+    (void)decoded_size;
+    *out_size = required_size;
+    free(decode_buf);
+    free(input_buf);
+    return ESP_OK;
+
+err:
+    free(decode_buf);
+    free(input_buf);
+    return ret;
+}
+#endif
+
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT
+static esp_err_t eaf_dec_decode_jpeg_software(const uint8_t *in_data, size_t in_size,
+        uint8_t *out_data, size_t *out_size, bool swap_color)
+{
+    esp_err_t ret = ESP_OK;
+    uint32_t w, h;
+    jpeg_dec_handle_t jpeg_dec = NULL;
+    jpeg_dec_io_t *jpeg_io = NULL;
+    jpeg_dec_header_info_t *out_info = NULL;
+
+    jpeg_dec_config_t config = {
+        .output_type = swap_color ? JPEG_PIXEL_FORMAT_RGB565_BE : JPEG_PIXEL_FORMAT_RGB565_LE,
+        .rotate = JPEG_ROTATE_0D,
+    };
+
+    ESP_GOTO_ON_ERROR(jpeg_dec_open(&config, &jpeg_dec), err, TAG, "JPEG decoder open failed");
+
+    jpeg_io = malloc(sizeof(jpeg_dec_io_t));
+    ESP_GOTO_ON_FALSE(jpeg_io, ESP_ERR_NO_MEM, err, TAG, "No mem for jpeg_io");
+
+    out_info = malloc(sizeof(jpeg_dec_header_info_t));
+    ESP_GOTO_ON_FALSE(out_info, ESP_ERR_NO_MEM, err, TAG, "No mem for out_info");
+
+    jpeg_io->inbuf = (unsigned char *)in_data;
+    jpeg_io->inbuf_len = in_size;
+
+    jpeg_error_t jpeg_ret = jpeg_dec_parse_header(jpeg_dec, jpeg_io, out_info);
+    ESP_GOTO_ON_FALSE(jpeg_ret == JPEG_ERR_OK, ESP_FAIL, err, TAG, "JPEG header parse failed");
+
+    w = out_info->width;
+    h = out_info->height;
+
+    size_t required_size = (size_t)w * (size_t)h * sizeof(gfx_color_t);
+    ESP_GOTO_ON_FALSE(*out_size >= required_size, ESP_ERR_INVALID_SIZE, err, TAG,
+                      "Buffer too small: need %zu, got %zu", required_size, *out_size);
+
+    jpeg_io->outbuf = out_data;
+    jpeg_ret = jpeg_dec_process(jpeg_dec, jpeg_io);
+    ESP_GOTO_ON_FALSE(jpeg_ret == JPEG_ERR_OK, ESP_FAIL, err, TAG, "JPEG decode failed: %d", jpeg_ret);
+
+    *out_size = required_size;
+    free(jpeg_io);
+    free(out_info);
+    jpeg_dec_close(jpeg_dec);
+    return ESP_OK;
+
+err:
+    if (jpeg_io) {
+        free(jpeg_io);
+    }
+    if (out_info) {
+        free(out_info);
+    }
+    if (jpeg_dec) {
+        jpeg_dec_close(jpeg_dec);
+    }
+    return ret;
+}
+#endif
 
 eaf_dec_type_t eaf_dec_probe_frame_info(eaf_dec_handle_t handle, int frame_index)
 {
@@ -607,60 +798,15 @@ hs_fail:
 esp_err_t eaf_dec_decode_jpeg(const uint8_t *in_data, size_t in_size,
                               uint8_t *out_data, size_t *out_size, bool swap_color)
 {
-    esp_err_t ret = ESP_OK;
-    uint32_t w, h;
-    jpeg_dec_handle_t jpeg_dec = NULL;
-    jpeg_dec_io_t *jpeg_io = NULL;
-    jpeg_dec_header_info_t *out_info = NULL;
-
-    jpeg_dec_config_t config = {
-        .output_type = swap_color ? JPEG_PIXEL_FORMAT_RGB565_BE : JPEG_PIXEL_FORMAT_RGB565_LE,
-        .rotate = JPEG_ROTATE_0D,
-    };
-
-    ESP_GOTO_ON_ERROR(jpeg_dec_open(&config, &jpeg_dec), err, TAG, "JPEG decoder open failed");
-
-    jpeg_io = malloc(sizeof(jpeg_dec_io_t));
-    ESP_GOTO_ON_FALSE(jpeg_io, ESP_ERR_NO_MEM, err, TAG, "No mem for jpeg_io");
-
-    out_info = malloc(sizeof(jpeg_dec_header_info_t));
-    ESP_GOTO_ON_FALSE(out_info, ESP_ERR_NO_MEM, err, TAG, "No mem for out_info");
-
-    jpeg_io->inbuf = (unsigned char *)in_data;
-    jpeg_io->inbuf_len = in_size;
-
-    jpeg_error_t jpeg_ret = jpeg_dec_parse_header(jpeg_dec, jpeg_io, out_info);
-    ESP_GOTO_ON_FALSE(jpeg_ret == JPEG_ERR_OK, ESP_FAIL, err, TAG, "JPEG header parse failed");
-
-    w = out_info->width;
-    h = out_info->height;
-
-    size_t required_size = w * h * 2;
-    ESP_GOTO_ON_FALSE(*out_size >= required_size, ESP_ERR_INVALID_SIZE, err, TAG,
-                      "Buffer too small: need %zu, got %zu", required_size, *out_size);
-
-    jpeg_io->outbuf = out_data;
-    jpeg_ret = jpeg_dec_process(jpeg_dec, jpeg_io);
-    ESP_GOTO_ON_FALSE(jpeg_ret == JPEG_ERR_OK, ESP_FAIL, err, TAG, "JPEG decode failed: %d", jpeg_ret);
-
-    *out_size = required_size;
-
-    free(jpeg_io);
-    free(out_info);
-    jpeg_dec_close(jpeg_dec);
-    return ESP_OK;
-
-err:
-    if (jpeg_io) {
-        free(jpeg_io);
+#if CONFIG_SOC_JPEG_DECODE_SUPPORTED
+    esp_err_t ret = eaf_dec_decode_jpeg_hardware(in_data, in_size, out_data, out_size, swap_color);
+    if (ret == ESP_OK) {
+        return ESP_OK;
     }
-    if (out_info) {
-        free(out_info);
-    }
-    if (jpeg_dec) {
-        jpeg_dec_close(jpeg_dec);
-    }
-    return ret;
+
+    ESP_LOGW(TAG, "Hardware JPEG decode fallback to software: %s", esp_err_to_name(ret));
+#endif
+    return eaf_dec_decode_jpeg_software(in_data, in_size, out_data, out_size, swap_color);
 }
 #endif // CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT
 
@@ -782,6 +928,9 @@ esp_err_t eaf_dec_init(const uint8_t *data, size_t data_len, eaf_dec_handle_t *r
     parser->total_frames = total_frames;
 
     *ret_parser = (eaf_dec_handle_t)parser;
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT && CONFIG_SOC_JPEG_DECODE_SUPPORTED
+    s_eaf_parser_count++;
+#endif
 
     return ESP_OK;
 
@@ -810,6 +959,15 @@ esp_err_t eaf_dec_deinit(eaf_dec_handle_t handle)
         }
         free(parser);
     }
+#if CONFIG_GFX_EAF_JPEG_DECODE_SUPPORT && CONFIG_SOC_JPEG_DECODE_SUPPORTED
+    if (s_eaf_parser_count > 0) {
+        s_eaf_parser_count--;
+    }
+    if (s_eaf_parser_count == 0 && s_eaf_jpeg_decoder_engine != NULL) {
+        jpeg_del_decoder_engine(s_eaf_jpeg_decoder_engine);
+        s_eaf_jpeg_decoder_engine = NULL;
+    }
+#endif
     return ESP_OK;
 }
 

--- a/src/widget/img/gfx_img.c
+++ b/src/widget/img/gfx_img.c
@@ -106,6 +106,7 @@ static esp_err_t gfx_img_draw(gfx_obj_t *obj, const gfx_draw_ctx_t *ctx)
         .header = header,
         .data = NULL,
         .data_size = 0,
+        .swap = ctx->swap,
         .user_data = NULL
     };
 
@@ -133,7 +134,7 @@ static esp_err_t gfx_img_draw(gfx_obj_t *obj, const gfx_draw_ctx_t *ctx)
         return ESP_OK;
     }
 
-    gfx_coord_t src_stride = image_width;
+    gfx_coord_t src_stride = (header.stride > 0U) ? (gfx_coord_t)(header.stride / GFX_PIXEL_SIZE_16BPP) : (gfx_coord_t)image_width;
 
     gfx_color_t *dest_pixels = GFX_DRAW_CTX_DEST_PTR(ctx, clip_area.x1, clip_area.y1);
     gfx_color_t *src_pixels = (gfx_color_t *)GFX_BUFFER_OFFSET_16BPP(image_data,
@@ -173,6 +174,7 @@ static esp_err_t gfx_img_resolve_src_payload(const gfx_img_src_t *src, const voi
 
     switch (src->type) {
     case GFX_IMG_SRC_TYPE_IMAGE_DSC:
+    case GFX_IMG_SRC_TYPE_JPEG:
         *out_payload = src->data;
         return ESP_OK;
     default:

--- a/src/widget/img/gfx_img_dec.c
+++ b/src/widget/img/gfx_img_dec.c
@@ -218,12 +218,20 @@ esp_err_t gfx_image_decoder_init(void)
         return ret;
     }
 
+    ret = gfx_image_decoder_register_jpeg();
+    if (ret != ESP_OK) {
+        gfx_image_decoder_deinit();
+        return ret;
+    }
+
     GFX_LOGD(TAG, "init image decoder: %d decoders registered", s_decoder_count);
     return ESP_OK;
 }
 
 esp_err_t gfx_image_decoder_deinit(void)
 {
+    gfx_image_decoder_unregister_jpeg();
+
     for (int i = 0; i < s_decoder_count; i++) {
         s_registered_decoders[i] = NULL;
     }

--- a/src/widget/img/gfx_img_dec_jpeg.c
+++ b/src/widget/img/gfx_img_dec_jpeg.c
@@ -1,0 +1,308 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sdkconfig.h"
+#include "esp_check.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#define GFX_LOG_MODULE GFX_LOG_MODULE_IMG_DEC
+#include "common/gfx_log_priv.h"
+#include "common/gfx_comm.h"
+#include "widget/img/gfx_img_dec_priv.h"
+
+#if CONFIG_SOC_JPEG_DECODE_SUPPORTED
+#include "driver/jpeg_decode.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define GFX_JPEG_HEADER_SOI_MSB 0xFF
+#define GFX_JPEG_HEADER_SOI_LSB 0xD8
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    uint8_t *input_buf;
+    size_t input_buf_size;
+    uint8_t *output_buf;
+    size_t output_buf_size;
+    uint32_t decoded_size;
+} gfx_img_dec_jpeg_ctx_t;
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static const char *TAG = "img_dec_jpeg";
+static jpeg_decoder_handle_t s_jpeg_decoder_engine = NULL;
+static bool s_jpeg_decoder_registered = false;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static esp_err_t gfx_img_dec_jpeg_info_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc, gfx_image_header_t *header);
+static esp_err_t gfx_img_dec_jpeg_open_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc);
+static void gfx_img_dec_jpeg_close_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc);
+static esp_err_t gfx_img_dec_jpeg_get_source(const gfx_image_decoder_dsc_t *dsc, const gfx_jpeg_dsc_t **out_src);
+static esp_err_t gfx_img_dec_jpeg_parse_header(const gfx_jpeg_dsc_t *jpeg_src, gfx_image_header_t *out_header,
+                                               uint32_t *out_process_w, uint32_t *out_process_h);
+static esp_err_t gfx_img_dec_jpeg_get_mcu_size(jpeg_down_sampling_type_t sample_method, uint32_t *out_mcu_w, uint32_t *out_mcu_h);
+static jpeg_dec_rgb_element_order_t gfx_img_dec_jpeg_get_rgb_order(bool swap);
+
+static gfx_image_decoder_t s_gfx_img_decoder_jpeg = {
+    .name = "jpeg_hw",
+    .info_cb = gfx_img_dec_jpeg_info_cb,
+    .open_cb = gfx_img_dec_jpeg_open_cb,
+    .close_cb = gfx_img_dec_jpeg_close_cb,
+};
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static esp_err_t gfx_img_dec_jpeg_get_source(const gfx_image_decoder_dsc_t *dsc, const gfx_jpeg_dsc_t **out_src)
+{
+    ESP_RETURN_ON_FALSE(dsc != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg source: decoder desc is NULL");
+    ESP_RETURN_ON_FALSE(out_src != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg source: output is NULL");
+    ESP_RETURN_ON_FALSE(dsc->src.type == GFX_IMG_SRC_TYPE_JPEG, ESP_ERR_INVALID_ARG, TAG, "jpeg source: src type mismatch");
+    ESP_RETURN_ON_FALSE(dsc->src.data != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg source: payload is NULL");
+
+    const gfx_jpeg_dsc_t *jpeg_src = (const gfx_jpeg_dsc_t *)dsc->src.data;
+    ESP_RETURN_ON_FALSE(jpeg_src->data != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg source: bitstream is NULL");
+    ESP_RETURN_ON_FALSE(jpeg_src->data_size >= 2U, ESP_ERR_INVALID_ARG, TAG, "jpeg source: bitstream is too small");
+    ESP_RETURN_ON_FALSE(jpeg_src->data[0] == GFX_JPEG_HEADER_SOI_MSB && jpeg_src->data[1] == GFX_JPEG_HEADER_SOI_LSB,
+                        ESP_ERR_INVALID_ARG, TAG, "jpeg source: invalid SOI marker");
+
+    *out_src = jpeg_src;
+    return ESP_OK;
+}
+
+static esp_err_t gfx_img_dec_jpeg_get_mcu_size(jpeg_down_sampling_type_t sample_method, uint32_t *out_mcu_w, uint32_t *out_mcu_h)
+{
+    ESP_RETURN_ON_FALSE(out_mcu_w != NULL && out_mcu_h != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg mcu: output is NULL");
+
+    switch (sample_method) {
+    case JPEG_DOWN_SAMPLING_YUV444:
+        *out_mcu_w = 8U;
+        *out_mcu_h = 8U;
+        return ESP_OK;
+    case JPEG_DOWN_SAMPLING_YUV422:
+        *out_mcu_w = 16U;
+        *out_mcu_h = 8U;
+        return ESP_OK;
+    case JPEG_DOWN_SAMPLING_YUV420:
+        *out_mcu_w = 16U;
+        *out_mcu_h = 16U;
+        return ESP_OK;
+    case JPEG_DOWN_SAMPLING_GRAY:
+        return ESP_ERR_NOT_SUPPORTED;
+    default:
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+}
+
+static esp_err_t gfx_img_dec_jpeg_parse_header(const gfx_jpeg_dsc_t *jpeg_src, gfx_image_header_t *out_header,
+                                               uint32_t *out_process_w, uint32_t *out_process_h)
+{
+    jpeg_decode_picture_info_t picture_info = {0};
+    uint32_t mcu_w = 0;
+    uint32_t mcu_h = 0;
+
+    ESP_RETURN_ON_FALSE(jpeg_src != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg header: source is NULL");
+    ESP_RETURN_ON_FALSE(out_header != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg header: output header is NULL");
+    ESP_RETURN_ON_FALSE(out_process_w != NULL && out_process_h != NULL, ESP_ERR_INVALID_ARG, TAG, "jpeg header: process size output is NULL");
+
+    ESP_RETURN_ON_ERROR(jpeg_decoder_get_info(jpeg_src->data, jpeg_src->data_size, &picture_info), TAG, "jpeg header: get info failed");
+    ESP_RETURN_ON_ERROR(gfx_img_dec_jpeg_get_mcu_size(picture_info.sample_method, &mcu_w, &mcu_h), TAG,
+                        "jpeg header: unsupported sample method %d", (int)picture_info.sample_method);
+    ESP_RETURN_ON_FALSE(picture_info.width > 0U && picture_info.height > 0U, ESP_ERR_INVALID_SIZE, TAG,
+                        "jpeg header: invalid picture size %" PRIu32 "x%" PRIu32, picture_info.width, picture_info.height);
+    ESP_RETURN_ON_FALSE(picture_info.width <= UINT16_MAX && picture_info.height <= UINT16_MAX, ESP_ERR_NOT_SUPPORTED, TAG,
+                        "jpeg header: picture size exceeds gfx header range");
+
+    *out_process_w = ((picture_info.width + mcu_w - 1U) / mcu_w) * mcu_w;
+    *out_process_h = ((picture_info.height + mcu_h - 1U) / mcu_h) * mcu_h;
+    ESP_RETURN_ON_FALSE((*out_process_w * GFX_PIXEL_SIZE_16BPP) <= UINT16_MAX, ESP_ERR_NOT_SUPPORTED, TAG,
+                        "jpeg header: stride exceeds gfx header range");
+
+    memset(out_header, 0, sizeof(*out_header));
+    out_header->cf = GFX_COLOR_FORMAT_RGB565;
+    out_header->w = (uint16_t)picture_info.width;
+    out_header->h = (uint16_t)picture_info.height;
+    out_header->stride = (uint16_t)(*out_process_w * GFX_PIXEL_SIZE_16BPP);
+
+    return ESP_OK;
+}
+
+static jpeg_dec_rgb_element_order_t gfx_img_dec_jpeg_get_rgb_order(bool swap)
+{
+    /* Match software/native semantics:
+     * swap=false -> RGB565 little-endian
+     * swap=true  -> RGB565 big-endian */
+    return swap ? JPEG_DEC_RGB_ELEMENT_ORDER_RGB : JPEG_DEC_RGB_ELEMENT_ORDER_BGR;
+}
+
+static esp_err_t gfx_img_dec_jpeg_info_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc, gfx_image_header_t *header)
+{
+    (void)decoder;
+
+    const gfx_jpeg_dsc_t *jpeg_src = NULL;
+    uint32_t process_w = 0;
+    uint32_t process_h = 0;
+
+    ESP_RETURN_ON_ERROR(gfx_img_dec_jpeg_get_source(dsc, &jpeg_src), TAG, "jpeg info: invalid source");
+    ESP_RETURN_ON_ERROR(gfx_img_dec_jpeg_parse_header(jpeg_src, header, &process_w, &process_h), TAG, "jpeg info: parse header failed");
+    (void)process_w;
+    (void)process_h;
+    return ESP_OK;
+}
+
+static esp_err_t gfx_img_dec_jpeg_open_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc)
+{
+    (void)decoder;
+
+    const gfx_jpeg_dsc_t *jpeg_src = NULL;
+    gfx_img_dec_jpeg_ctx_t *ctx = NULL;
+    gfx_image_header_t header = {0};
+    jpeg_decode_memory_alloc_cfg_t input_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_INPUT_BUFFER,
+    };
+    jpeg_decode_memory_alloc_cfg_t output_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
+    };
+    jpeg_decode_cfg_t decode_cfg = {
+        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .rgb_order = gfx_img_dec_jpeg_get_rgb_order(dsc->swap),
+        .conv_std = JPEG_YUV_RGB_CONV_STD_BT601,
+    };
+    uint32_t process_w = 0;
+    uint32_t process_h = 0;
+    uint32_t decoded_size = 0;
+    size_t requested_output_size = 0;
+    esp_err_t ret = ESP_OK;
+
+    ESP_RETURN_ON_FALSE(s_jpeg_decoder_engine != NULL, ESP_ERR_INVALID_STATE, TAG, "jpeg open: decoder engine is not ready");
+    ESP_RETURN_ON_ERROR(gfx_img_dec_jpeg_get_source(dsc, &jpeg_src), TAG, "jpeg open: invalid source");
+    ESP_RETURN_ON_ERROR(gfx_img_dec_jpeg_parse_header(jpeg_src, &header, &process_w, &process_h), TAG, "jpeg open: parse header failed");
+
+    ctx = calloc(1, sizeof(*ctx));
+    ESP_GOTO_ON_FALSE(ctx != NULL, ESP_ERR_NO_MEM, err, TAG, "jpeg open: no mem for context");
+
+    ctx->input_buf = jpeg_alloc_decoder_mem(jpeg_src->data_size, &input_mem_cfg, &ctx->input_buf_size);
+    ESP_GOTO_ON_FALSE(ctx->input_buf != NULL, ESP_ERR_NO_MEM, err, TAG, "jpeg open: no mem for input buffer");
+    memcpy(ctx->input_buf, jpeg_src->data, jpeg_src->data_size);
+
+    requested_output_size = (size_t)process_w * (size_t)process_h * GFX_PIXEL_SIZE_16BPP;
+    ctx->output_buf = jpeg_alloc_decoder_mem(requested_output_size, &output_mem_cfg, &ctx->output_buf_size);
+    ESP_GOTO_ON_FALSE(ctx->output_buf != NULL, ESP_ERR_NO_MEM, err, TAG, "jpeg open: no mem for output buffer");
+
+    ret = jpeg_decoder_process(s_jpeg_decoder_engine, &decode_cfg, ctx->input_buf, jpeg_src->data_size,
+                               ctx->output_buf, ctx->output_buf_size, &decoded_size);
+    ESP_GOTO_ON_ERROR(ret, err, TAG, "jpeg open: hardware decode failed");
+
+    ctx->decoded_size = decoded_size;
+    dsc->header = header;
+    dsc->data = ctx->output_buf;
+    dsc->data_size = ctx->decoded_size;
+    dsc->user_data = ctx;
+
+    GFX_LOGD(TAG, "jpeg open: decoded %ux%u stride=%u swap=%d",
+             dsc->header.w, dsc->header.h, dsc->header.stride, dsc->swap);
+    return ESP_OK;
+
+err:
+    if (ctx != NULL) {
+        free(ctx->output_buf);
+        free(ctx->input_buf);
+        free(ctx);
+    }
+    return ret;
+}
+
+static void gfx_img_dec_jpeg_close_cb(gfx_image_decoder_t *decoder, gfx_image_decoder_dsc_t *dsc)
+{
+    (void)decoder;
+
+    if (dsc == NULL || dsc->src.type != GFX_IMG_SRC_TYPE_JPEG || dsc->user_data == NULL) {
+        return;
+    }
+
+    gfx_img_dec_jpeg_ctx_t *ctx = (gfx_img_dec_jpeg_ctx_t *)dsc->user_data;
+    free(ctx->output_buf);
+    free(ctx->input_buf);
+    free(ctx);
+
+    dsc->data = NULL;
+    dsc->data_size = 0;
+    dsc->user_data = NULL;
+}
+
+/**********************
+ *   PUBLIC FUNCTIONS
+ **********************/
+
+esp_err_t gfx_image_decoder_register_jpeg(void)
+{
+    esp_err_t ret = ESP_OK;
+    jpeg_decode_engine_cfg_t engine_cfg = {
+        .intr_priority = 0,
+        .timeout_ms = -1,
+    };
+
+    if (s_jpeg_decoder_registered) {
+        return ESP_OK;
+    }
+
+    ret = jpeg_new_decoder_engine(&engine_cfg, &s_jpeg_decoder_engine);
+    ESP_RETURN_ON_ERROR(ret, TAG, "jpeg decoder register: create engine failed");
+
+    ret = gfx_image_decoder_register(&s_gfx_img_decoder_jpeg);
+    if (ret != ESP_OK) {
+        jpeg_del_decoder_engine(s_jpeg_decoder_engine);
+        s_jpeg_decoder_engine = NULL;
+        return ret;
+    }
+
+    s_jpeg_decoder_registered = true;
+    GFX_LOGD(TAG, "jpeg decoder register: hardware decoder ready");
+    return ESP_OK;
+}
+
+esp_err_t gfx_image_decoder_unregister_jpeg(void)
+{
+    if (s_jpeg_decoder_engine != NULL) {
+        jpeg_del_decoder_engine(s_jpeg_decoder_engine);
+        s_jpeg_decoder_engine = NULL;
+    }
+
+    s_jpeg_decoder_registered = false;
+    return ESP_OK;
+}
+
+#else
+
+esp_err_t gfx_image_decoder_register_jpeg(void)
+{
+    return ESP_OK;
+}
+
+esp_err_t gfx_image_decoder_unregister_jpeg(void)
+{
+    return ESP_OK;
+}
+
+#endif

--- a/src/widget/img/gfx_img_dec_priv.h
+++ b/src/widget/img/gfx_img_dec_priv.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "esp_err.h"
 #include "widget/gfx_img.h"
@@ -32,6 +33,7 @@ typedef struct {
     gfx_image_header_t header;  /**< Image header information */
     const uint8_t *data;        /**< Decoded/native image pixel data */
     uint32_t data_size;         /**< Size of decoded data */
+    bool swap;                  /**< Target framebuffer byte order */
     void *user_data;            /**< User data for decoder */
 } gfx_image_decoder_dsc_t;
 
@@ -55,6 +57,8 @@ esp_err_t gfx_image_decoder_open(gfx_image_decoder_dsc_t *dsc);
 void gfx_image_decoder_close(gfx_image_decoder_dsc_t *dsc);
 esp_err_t gfx_image_decoder_init(void);
 esp_err_t gfx_image_decoder_deinit(void);
+esp_err_t gfx_image_decoder_register_jpeg(void);
+esp_err_t gfx_image_decoder_unregister_jpeg(void);
 
 #ifdef __cplusplus
 }

--- a/src/widget/img/gfx_mesh_img.c
+++ b/src/widget/img/gfx_mesh_img.c
@@ -367,6 +367,7 @@ static esp_err_t gfx_mesh_img_validate_src(const gfx_img_src_t *src)
 
     switch (src->type) {
     case GFX_IMG_SRC_TYPE_IMAGE_DSC:
+    case GFX_IMG_SRC_TYPE_JPEG:
         return ESP_OK;
     default:
         return ESP_ERR_NOT_SUPPORTED;
@@ -456,6 +457,7 @@ static esp_err_t gfx_mesh_img_draw(gfx_obj_t *obj, const gfx_draw_ctx_t *ctx)
         return ESP_ERR_NOT_SUPPORTED;
     }
 
+    decoder_dsc.swap = ctx->swap;
     ESP_RETURN_ON_ERROR(gfx_mesh_img_prepare_decoder(mesh, &decoder_dsc), TAG, "draw mesh image: open decoder failed");
 
     if (decoder_dsc.data == NULL) {


### PR DESCRIPTION
This change adds hardware JPEG decode support for JPEG-based EAF playback in esp_emote_gfx, with software fallback on unsupported targets. 